### PR TITLE
feat: update actionSheet and contextMenu event handlers

### DIFF
--- a/src/Pages/ActionSheetPage.vue
+++ b/src/Pages/ActionSheetPage.vue
@@ -1,8 +1,7 @@
 <template>
   <div id="main">
     <!-- Instantiate the non-visual action sheet component -->
-    <flutter-cupertino-action-sheet ref="actionSheet" @share="handleShare" @delete="handleDelete"
-      @archive="handleArchive" @cancel="handleCancel" />
+    <flutter-cupertino-action-sheet ref="actionSheet" @select="handleSelect" />
 
     <webf-listview id="list">
       <div class="component-section">
@@ -99,19 +98,9 @@ export default {
     },
 
     // Event Handlers
-    handleShare(event) {
-      console.log('Action Sheet Event: share', event.detail);
+    handleSelect(event) {
+      console.log('Action Sheet Event: select', event.detail);
     },
-    handleDelete(event) {
-      console.log('Action Sheet Event: delete', event.detail);
-    },
-    handleArchive(event) {
-      console.log('Action Sheet Event: archive', event.detail);
-    },
-    handleCancel(event) {
-      console.log('Action Sheet Event: cancel', event.detail);
-    },
-    // Add handlers for other events like proceed, review if needed
   }
 };
 </script>

--- a/src/Pages/ContextMenuPage.vue
+++ b/src/Pages/ContextMenuPage.vue
@@ -28,7 +28,7 @@
               />
             </div>
             <div class="menu-container">
-              <flutter-cupertino-context-menu ref="menu1" @defaultAction="onDefaultAction" @delete="onDelete">
+              <flutter-cupertino-context-menu ref="menu1" @select="handleSelect">
                 <div class="preview-box">
                   <flutter-cupertino-icon type="photo" style="font-size: 48px;" />
                   <div class="preview-text">Switch controlled</div>
@@ -41,7 +41,7 @@
           <div class="component-item">
             <div class="item-label">Custom Menu Items</div>
             <div class="menu-container">
-              <flutter-cupertino-context-menu ref="menu2" @share="onShare" @favorite="onFavorite">
+              <flutter-cupertino-context-menu ref="menu2" @select="handleSelect">
                 <div class="preview-box">
                   <flutter-cupertino-icon type="heart" style="font-size: 48px;" />
                   <div class="preview-text">Custom menu item</div>
@@ -54,8 +54,7 @@
           <div class="component-item">
             <div class="item-label">With Destructive Action</div>
             <div class="menu-container">
-              <flutter-cupertino-context-menu ref="menu3" enable-haptic-feedback @open="onOpen" @edit="onEdit"
-                @delete="onDelete">
+              <flutter-cupertino-context-menu ref="menu3" enable-haptic-feedback @select="handleSelect">
                 <div class="preview-box">
                   <flutter-cupertino-icon type="doc_text" style="font-size: 48px;" />
                   <div class="preview-text">Document action</div>
@@ -68,8 +67,7 @@
           <div class="component-item">
             <div class="item-label">With Default Action</div>
             <div class="menu-container">
-              <flutter-cupertino-context-menu ref="menu4" enable-haptic-feedback @call="onCall" @message="onMessage"
-                @email="onEmail">
+              <flutter-cupertino-context-menu ref="menu4" enable-haptic-feedback @select="handleSelect">
                 <div class="preview-box">
                   <flutter-cupertino-icon type="person_circle" style="font-size: 48px;" />
                   <div class="preview-text">Contact</div>
@@ -165,15 +163,9 @@ export default {
       });
     },
     // --- Event Handlers ---
-    onShare() { console.log('Share pressed'); },
-    onFavorite() { console.log('Favorite pressed'); },
-    onOpen() { console.log('Open pressed'); },
-    onDelete() { console.log('Delete pressed (menu0, menu1, or menu3)'); },
-    onCall() { console.log('Call pressed'); },
-    onMessage() { console.log('Message pressed'); },
-    onEmail() { console.log('Email pressed'); },
-    onDefaultAction() { console.log('Default action pressed (menu1)'); },
-    onEdit() { console.log('Edit pressed'); }
+    handleSelect(event) {
+      console.log('Context Menu Event: select', event.detail);
+    },
   },
 }
 </script>


### PR DESCRIPTION
This pull request simplifies event handling for `flutter-cupertino-action-sheet` and `flutter-cupertino-context-menu` components across `ActionSheetPage.vue` and `ContextMenuPage.vue`. It consolidates multiple event handlers into a single `handleSelect` method, improving maintainability and reducing code duplication.

### Changes to `ActionSheetPage.vue`:

* Replaced individual event bindings (`@share`, `@delete`, `@archive`, `@cancel`) with a single `@select` event binding for the `flutter-cupertino-action-sheet` component.
* Removed multiple event handler methods (`handleShare`, `handleDelete`, `handleArchive`, `handleCancel`) and introduced a unified `handleSelect` method to log the `select` event details.

### Changes to `ContextMenuPage.vue`:

* Replaced various event bindings (`@defaultAction`, `@delete`, `@share`, `@favorite`, `@open`, `@edit`, `@call`, `@message`, `@email`) with a single `@select` event binding for all instances of the `flutter-cupertino-context-menu` component. [[1]](diffhunk://#diff-e2608e3a9c15a6713328a07c9826239d2d2f5008030b0db0268f9e281c09816eL31-R31) [[2]](diffhunk://#diff-e2608e3a9c15a6713328a07c9826239d2d2f5008030b0db0268f9e281c09816eL44-R44) [[3]](diffhunk://#diff-e2608e3a9c15a6713328a07c9826239d2d2f5008030b0db0268f9e281c09816eL57-R57) [[4]](diffhunk://#diff-e2608e3a9c15a6713328a07c9826239d2d2f5008030b0db0268f9e281c09816eL71-R70)
* Removed individual event handler methods (`onShare`, `onFavorite`, `onOpen`, `onDelete`, `onCall`, `onMessage`, `onEmail`, `onDefaultAction`, `onEdit`) and added a unified `handleSelect` method to log the `select` event details.